### PR TITLE
Created a new view to expose the business data

### DIFF
--- a/src/SFA.DAS.EmployerIncentives.Database/SFA.DAS.EmployerIncentives.Database.sqlproj
+++ b/src/SFA.DAS.EmployerIncentives.Database/SFA.DAS.EmployerIncentives.Database.sqlproj
@@ -96,5 +96,6 @@
   <ItemGroup>
     <None Include="SFA.DAS.EmployerIncentives.Database.publish.xml" />
     <None Include="update-model.publish.xml" />
+    <None Include="Views\BusinessDashboardApplications.sql" />
   </ItemGroup>
 </Project>

--- a/src/SFA.DAS.EmployerIncentives.Database/Views/BusinessDashboardApplications.sql
+++ b/src/SFA.DAS.EmployerIncentives.Database/Views/BusinessDashboardApplications.sql
@@ -1,0 +1,27 @@
+﻿CREATE VIEW [dbo].[BusinessDashboardApplications]
+	AS 
+		select
+			month(PlannedStartDate) as [Planned Start Month],
+			year(PlannedStartDate) as [Planned Start Year],
+			count(distinct(iaa.incentiveapplicationid)) as Applications, 
+			avg(cast(Learners as float)) as [Mean learners per app],
+			count(Learners) as [Num Learners],
+			sum(iaa.totalincentiveamount) as [Total Value], 
+			sum(case when iaa.totalincentiveamount < '2000.00' then iaa.totalincentiveamount else 0 end) as [<£2000],
+			sum(case when iaa.totalincentiveamount >= '2000.00' then iaa.totalincentiveamount else 0 end) as [>=£2000]
+		from
+			[dbo].[IncentiveApplicationApprenticeship] iaa
+			left join [dbo].[IncentiveApplication] ia on ia.Id=iaa.IncentiveApplicationId
+			left join	  (SELECT 
+							[IncentiveApplicationId],
+							count(*) as Learners,
+							status
+							FROM [dbo].[IncentiveApplicationApprenticeship] iaa2
+							left join [dbo].[IncentiveApplication] ia2 on ia2.Id=iaa2.IncentiveApplicationId
+							group by [IncentiveApplicationId], status
+						  ) q on  q.IncentiveApplicationId = iaa.IncentiveApplicationId
+		where
+			q.status = 'Submitted'
+		group by 
+			month(PlannedStartDate), year(PlannedStartDate)
+		order by year(PlannedStartDate), month(PlannedStartDate)

--- a/src/SFA.DAS.EmployerIncentives.Database/Views/BusinessDashboardApplications.sql
+++ b/src/SFA.DAS.EmployerIncentives.Database/Views/BusinessDashboardApplications.sql
@@ -24,4 +24,3 @@
 			q.status = 'Submitted'
 		group by 
 			month(PlannedStartDate), year(PlannedStartDate)
-		order by year(PlannedStartDate), month(PlannedStartDate)


### PR DESCRIPTION
This view is so that I can produce a business focus dashboard which exposes the numbers that we need to report to other areas of the business. The current applications dashboard is not suitable for this.

The method for splitting by payment value is a surrogate for recalculating the age. This will give the business the split they need but without adding logic in the view to cal the age. I didn't want to have the logic in multiple places.

Branch name doesn't include the ticket as the ticket was made after the work started

https://skillsfundingagency.atlassian.net/browse/EI-655
