### PR TITLE
EI-1845 Compliance Reinstate Function should not reinstate any applications that are EMPLOYER Withdrawn

### DIFF
--- a/src/SFA.DAS.EmployerIncentives.Commands/Withdrawals/ReinstateWithdrawal/ReinstateWithdrawalCommandHandler.cs
+++ b/src/SFA.DAS.EmployerIncentives.Commands/Withdrawals/ReinstateWithdrawal/ReinstateWithdrawalCommandHandler.cs
@@ -1,7 +1,10 @@
 ﻿using SFA.DAS.EmployerIncentives.Abstractions.Commands;
 using SFA.DAS.EmployerIncentives.Commands.Persistence;
 using SFA.DAS.EmployerIncentives.Commands.Types.Withdrawals;
+using SFA.DAS.EmployerIncentives.Data.IncentiveApplication;
 using SFA.DAS.EmployerIncentives.Domain.Exceptions;
+using SFA.DAS.EmployerIncentives.Enums;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,10 +14,13 @@ namespace SFA.DAS.EmployerIncentives.Commands.Withdrawals.ComplianceWithdrawal
     public class ReinstateWithdrawalCommandHandler : ICommandHandler<ReinstateWithdrawalCommand>
     {
         private readonly IIncentiveApplicationDomainRepository _domainRepository;
+        private readonly IIncentiveApplicationStatusAuditDataRepository _incentiveApplicationStatusAuditDataRepository;
 
-        public ReinstateWithdrawalCommandHandler(IIncentiveApplicationDomainRepository domainRepository)
+        public ReinstateWithdrawalCommandHandler(IIncentiveApplicationDomainRepository domainRepository,
+            IIncentiveApplicationStatusAuditDataRepository incentiveApplicationStatusAuditDataRepository)
         {
             _domainRepository = domainRepository;
+            _incentiveApplicationStatusAuditDataRepository = incentiveApplicationStatusAuditDataRepository; 
         }
 
         public async Task Handle(ReinstateWithdrawalCommand command, CancellationToken cancellationToken = default)
@@ -29,7 +35,8 @@ namespace SFA.DAS.EmployerIncentives.Commands.Withdrawals.ComplianceWithdrawal
             {
                 foreach(var apprenticeship in application.Apprenticeships)
                 {
-                    if(apprenticeship.ULN == command.ULN && apprenticeship.WithdrawnByCompliance)
+                    if(apprenticeship.ULN == command.ULN && apprenticeship.WithdrawnByCompliance &&
+                        !_incentiveApplicationStatusAuditDataRepository.GetByApplicationApprenticeshipId(apprenticeship.Id).Any(x => x.Process == IncentiveApplicationStatus.EmployerWithdrawn))
                     {
                         application.ReinstateWithdrawal(apprenticeship);
                     }

--- a/src/SFA.DAS.EmployerIncentives.Data/IncentiveApplication/IIncentiveApplicationStatusAuditDataRepository.cs
+++ b/src/SFA.DAS.EmployerIncentives.Data/IncentiveApplication/IIncentiveApplicationStatusAuditDataRepository.cs
@@ -1,10 +1,14 @@
-﻿using SFA.DAS.EmployerIncentives.Domain.ValueObjects;
+﻿using SFA.DAS.EmployerIncentives.Data.Models;
+using SFA.DAS.EmployerIncentives.Domain.ValueObjects;
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace SFA.DAS.EmployerIncentives.Data.IncentiveApplication
 {
     public interface IIncentiveApplicationStatusAuditDataRepository
     {
-        Task Add(IncentiveApplicationAudit incentiveApplicationAudit);        
+        Task Add(IncentiveApplicationAudit incentiveApplicationAudit);
+        List<IncentiveApplicationStatusAudit> GetByApplicationApprenticeshipId(Guid incentiveApplicationApprenticeshipId);
     }
 }

--- a/src/SFA.DAS.EmployerIncentives.Data/IncentiveApplication/IncentiveApplicationStatusAuditDataRepository.cs
+++ b/src/SFA.DAS.EmployerIncentives.Data/IncentiveApplication/IncentiveApplicationStatusAuditDataRepository.cs
@@ -2,6 +2,8 @@
 using SFA.DAS.EmployerIncentives.Data.Models;
 using SFA.DAS.EmployerIncentives.Domain.ValueObjects;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace SFA.DAS.EmployerIncentives.Data.IncentiveApplication
@@ -19,6 +21,11 @@ namespace SFA.DAS.EmployerIncentives.Data.IncentiveApplication
         public async Task Add(IncentiveApplicationAudit incentiveApplicationAudit)
         {
             await _dbContext.AddAsync(incentiveApplicationAudit.Map());
+        }
+
+        public List<IncentiveApplicationStatusAudit> GetByApplicationApprenticeshipId(Guid incentiveApplicationApprenticeshipId)
+        {
+            return _dbContext.IncentiveApplicationStatusAudits.Where(x => x.IncentiveApplicationApprenticeshipId == incentiveApplicationApprenticeshipId).ToList();
         }
     }
 }

--- a/src/tests/SFA.DAS.EmployerIncentives.Commands.UnitTests/Withdrawals/ReinstateWithdrawal/Handlers/WhenHandlingReinstateWithdrawalCommand.cs
+++ b/src/tests/SFA.DAS.EmployerIncentives.Commands.UnitTests/Withdrawals/ReinstateWithdrawal/Handlers/WhenHandlingReinstateWithdrawalCommand.cs
@@ -9,10 +9,12 @@ using NUnit.Framework;
 using SFA.DAS.EmployerIncentives.Commands.Persistence;
 using SFA.DAS.EmployerIncentives.Commands.Types.Withdrawals;
 using SFA.DAS.EmployerIncentives.Commands.Withdrawals.ComplianceWithdrawal;
+using SFA.DAS.EmployerIncentives.Data.IncentiveApplication;
 using SFA.DAS.EmployerIncentives.Domain.Exceptions;
 using SFA.DAS.EmployerIncentives.Domain.Factories;
 using SFA.DAS.EmployerIncentives.Domain.IncentiveApplications;
 using SFA.DAS.EmployerIncentives.Domain.IncentiveApplications.Models;
+using SFA.DAS.EmployerIncentives.Enums;
 using SFA.DAS.EmployerIncentives.UnitTests.Shared.AutoFixtureCustomizations;
 
 namespace SFA.DAS.EmployerIncentives.Commands.UnitTests.Withdrawals.ReinstateWithdrawal.Handlers
@@ -21,7 +23,9 @@ namespace SFA.DAS.EmployerIncentives.Commands.UnitTests.Withdrawals.ReinstateWit
     {
         private ReinstateWithdrawalCommandHandler _sut;
         private Mock<IIncentiveApplicationDomainRepository> _mockDomainRepository;
-         
+        private Mock<IIncentiveApplicationStatusAuditDataRepository> _mockIncentiveApplicationStatusAuditDataRepository;
+
+
         private Fixture _fixture;
 
         [SetUp]
@@ -31,8 +35,9 @@ namespace SFA.DAS.EmployerIncentives.Commands.UnitTests.Withdrawals.ReinstateWit
             _fixture.Customize(new IncentiveApplicationCustomization());
 
             _mockDomainRepository = new Mock<IIncentiveApplicationDomainRepository>();
-            
-            _sut = new ReinstateWithdrawalCommandHandler(_mockDomainRepository.Object);
+            _mockIncentiveApplicationStatusAuditDataRepository = new Mock<IIncentiveApplicationStatusAuditDataRepository>();
+
+            _sut = new ReinstateWithdrawalCommandHandler(_mockDomainRepository.Object, _mockIncentiveApplicationStatusAuditDataRepository.Object);
         }
 
         [Test]
@@ -58,6 +63,11 @@ namespace SFA.DAS.EmployerIncentives.Commands.UnitTests.Withdrawals.ReinstateWit
                     })
                 .Create();
 
+            var lstIncentiveApplicationStatusAudit = _fixture.Build<Data.Models.IncentiveApplicationStatusAudit>()
+                    .With(a => a.IncentiveApplicationApprenticeshipId, apprenticeshipModel.Id)
+                    .With(a => a.Process, IncentiveApplicationStatus.ComplianceWithdrawn)
+                    .CreateMany(2).ToList();
+
             var testApplication = new IncentiveApplicationFactory().GetExisting(incentiveApplicationModel.Id, incentiveApplicationModel);
 
             var applications = new List<IncentiveApplication>()
@@ -70,6 +80,8 @@ namespace SFA.DAS.EmployerIncentives.Commands.UnitTests.Withdrawals.ReinstateWit
             _mockDomainRepository
                 .Setup(m => m.Find(command.AccountLegalEntityId, command.ULN))
                 .ReturnsAsync(applications);
+
+            _mockIncentiveApplicationStatusAuditDataRepository.Setup(x => x.GetByApplicationApprenticeshipId(It.IsAny<Guid>())).Returns(lstIncentiveApplicationStatusAudit);
           
             //Act
             await _sut.Handle(command);
@@ -84,6 +96,72 @@ namespace SFA.DAS.EmployerIncentives.Commands.UnitTests.Withdrawals.ReinstateWit
                     !a.WithdrawnByEmployer) == 1)),
                  Times.Once);
         }
+
+        
+        [Test]
+        public async Task Then_changes_to_the_application_are_persisted_to_the_domain_repository_for_matching_ULNs_ButNotReinstateted()
+        {
+            //Arrange            
+            var command = _fixture.Create<ReinstateWithdrawalCommand>();
+
+            var apprenticeshipModel = _fixture
+                .Build<ApprenticeshipModel>()
+                .With(a => a.ULN, command.ULN)
+                .With(a => a.WithdrawnByCompliance, true)
+                .With(a => a.WithdrawnByEmployer, true)
+                .Create();
+
+            var incentiveApplicationModel = _fixture
+                .Build<IncentiveApplicationModel>()
+                .With(i => i.ApprenticeshipModels,
+                    new List<ApprenticeshipModel> {
+                        _fixture.Create<ApprenticeshipModel>(),
+                        apprenticeshipModel,
+                        _fixture.Create<ApprenticeshipModel>(),
+                    })
+                .Create();
+
+            var lstIncentiveApplicationStatusAudit = _fixture.Build<Data.Models.IncentiveApplicationStatusAudit>()
+                    .With(a => a.IncentiveApplicationApprenticeshipId, apprenticeshipModel.Id)
+                    .With(a => a.Process, IncentiveApplicationStatus.ComplianceWithdrawn)
+                    .CreateMany(2).ToList();
+
+            var employerWithdrawnAudit = _fixture.Build<Data.Models.IncentiveApplicationStatusAudit>()
+                    .With(a => a.IncentiveApplicationApprenticeshipId, apprenticeshipModel.Id)
+                    .With(a => a.Process, IncentiveApplicationStatus.EmployerWithdrawn)
+                    .Create();
+
+            lstIncentiveApplicationStatusAudit.Insert(0, employerWithdrawnAudit);
+
+            var testApplication = new IncentiveApplicationFactory().GetExisting(incentiveApplicationModel.Id, incentiveApplicationModel);
+
+            var applications = new List<IncentiveApplication>()
+            {
+                _fixture.Create<IncentiveApplication>(),
+                testApplication,
+                _fixture.Create<IncentiveApplication>()
+            };
+
+            _mockDomainRepository
+                .Setup(m => m.Find(command.AccountLegalEntityId, command.ULN))
+                .ReturnsAsync(applications);
+
+            _mockIncentiveApplicationStatusAuditDataRepository.Setup(x => x.GetByApplicationApprenticeshipId(It.IsAny<Guid>())).Returns(lstIncentiveApplicationStatusAudit);
+
+            //Act
+            await _sut.Handle(command);
+
+            //Assert
+            _mockDomainRepository
+                .Verify(m => m.Save(It.Is<IncentiveApplication>(a =>
+                 a.Id == testApplication.Id &&
+                 a.Apprenticeships.Count(a =>
+                    a.ULN == command.ULN &&
+                    !a.WithdrawnByCompliance &&
+                    !a.WithdrawnByEmployer) == 1)),
+                 Times.Never);
+        }
+       
 
         [Test]
         public async Task Then_applications_not_withdrawn_by_compliance_are_not_reinstated()
@@ -108,6 +186,11 @@ namespace SFA.DAS.EmployerIncentives.Commands.UnitTests.Withdrawals.ReinstateWit
                     })
                 .Create();
 
+            var lstIncentiveApplicationStatusAudit = _fixture.Build<Data.Models.IncentiveApplicationStatusAudit>()
+                    .With(a => a.IncentiveApplicationApprenticeshipId, apprenticeshipModel.Id)
+                    .With(a => a.Process, IncentiveApplicationStatus.ComplianceWithdrawn)
+                    .CreateMany(2).ToList();
+
             var testApplication = new IncentiveApplicationFactory().GetExisting(incentiveApplicationModel.Id, incentiveApplicationModel);
 
             var applications = new List<IncentiveApplication>()
@@ -120,6 +203,8 @@ namespace SFA.DAS.EmployerIncentives.Commands.UnitTests.Withdrawals.ReinstateWit
             _mockDomainRepository
                 .Setup(m => m.Find(command.AccountLegalEntityId, command.ULN))
                 .ReturnsAsync(applications);
+
+            _mockIncentiveApplicationStatusAuditDataRepository.Setup(x => x.GetByApplicationApprenticeshipId(It.IsAny<Guid>())).Returns(lstIncentiveApplicationStatusAudit);
 
             //Act
             await _sut.Handle(command);


### PR DESCRIPTION
Ticket No: Compliance Reinstate Function should not reinstate any applications that are EMPLOYER Withdrawn
If there are any records in the IncentiveApplicationStatusAudit for a given application that are EMPLOYER Withdrawn they should not be Reinstate?